### PR TITLE
change the order of known_peer_list 

### DIFF
--- a/2.1 Peer Discovery.md
+++ b/2.1 Peer Discovery.md
@@ -61,7 +61,11 @@ Upon reception of a [DiscoveryResponse](#DiscoveryResponse) message, a peer *mus
 * verifying that the signature of the [DiscoveryResponse](#DiscoveryResponse) message is valid and discard the message otherwise;
 * checking that the `req_hash` field matches a discovery request (i.e., *DiscoveryRequest*) previously sent and not expired.
 
-Upon successful validation of a received [DiscoveryResponse](#DiscoveryResponse) message, a peer *should* add the peers contained in the `peers` field to the top of the `known_peer_list`.
+Upon successful validation of a received [DiscoveryResponse](#DiscoveryResponse) message, a peer *should* add the peers contained in the `peers` field to the end of the `known_peer_list`. 
+
+It is worthwile to note that the order in which the `known_peer_list` is worked through is important. For example if the peer is added to the front of the `known_peer_list`, it is possible for an adversary to fill the `verified_peer_list` with a selection of its own nodes. 
+
+
 
 ## 2.1.4.5 Messages
 


### PR DESCRIPTION
The order how we work through the known_peer_list is important, if we want to make it more difficult for the adversary to fill the verified_peer_list of an honest node and to learn quickly about the honest part of the network. This small change should do the job. 