### PR TITLE
Fix math display

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const math = require('remark-math');
+const katex = require('rehype-katex');
 
 module.exports = {
     plugins: [
@@ -10,7 +12,8 @@ module.exports = {
                 routeBasePath: 'IOTA-2.0-Research-Specifications',
                 sidebarPath: path.resolve(__dirname, '../sidebars.js'),
                 editUrl: 'https://github.com/iotaledger/IOTA-2.0-Research-Specifications/edit/main/docusaurus',
-                remarkPlugins: [require('remark-math'), require('rehype-katex')],
+                remarkPlugins: [math],
+                rehypePlugins: [katex],
                 include: ['*.md'],
                 exclude: ['README.md'],
             }

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -11,7 +11,8 @@
     "node": ">=14.14.0"
   },
   "dependencies": {
-    "rehype-katex": "4",
+    "hast-util-is-element": "1.1.0",
+    "rehype-katex": "5",
     "remark-math": "3"
   },
   "devDependencies": {

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -4153,7 +4153,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.19.0, commander@npm:^2.20.0":
+"commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
@@ -4174,7 +4174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^8.3.0":
+"commander@npm:^8.0.0, commander@npm:^8.3.0":
   version: 8.3.0
   resolution: "commander@npm:8.3.0"
   checksum: 0f82321821fc27b83bd409510bb9deeebcfa799ff0bf5d102128b500b7af22872c0c92cb6a0ebc5a4cf19c6b550fba9cedfa7329d18c6442a625f851377bacf0
@@ -6049,7 +6049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hast-util-is-element@npm:^1.0.0":
+"hast-util-is-element@npm:1.1.0, hast-util-is-element@npm:^1.0.0":
   version: 1.1.0
   resolution: "hast-util-is-element@npm:1.1.0"
   checksum: 30fad3f65e7ab2f0efd5db9e7344d0820b70971988dfe79f62d8447598b2a1ce8a59cd4bfc05ae0d9a1c451b9b53cbe1023743d7eac764d64720b6b73475f62f
@@ -6635,7 +6635,8 @@ __metadata:
   resolution: "iota-2.0-specifications@workspace:."
   dependencies:
     "@iota-community/iota-wiki-cli": "iota-community/iota-wiki-cli#v2"
-    rehype-katex: 4
+    hast-util-is-element: 1.1.0
+    rehype-katex: 5
     remark-math: 3
   languageName: unknown
   linkType: soft
@@ -7101,14 +7102,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"katex@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "katex@npm:0.12.0"
+"katex@npm:^0.13.0":
+  version: 0.13.24
+  resolution: "katex@npm:0.13.24"
   dependencies:
-    commander: ^2.19.0
+    commander: ^8.0.0
   bin:
     katex: cli.js
-  checksum: f424c90b2b43034163cee37dd75f7c1f93206580cbaea07703a322010b615c32249d4648974d58f7345ad113431a43c2e8ae2118aed3a06fe37ad46dfdcf6d10
+  checksum: 1b7c8295867073d0db4f6fb41ef1c0e3418b8e23924ff61b446b36134cb74cdadc7242dfbfb922d9c32f0b15eda6160a08cd30948c4e78141966ca2991a1726b
   languageName: node
   linkType: hard
 
@@ -9535,17 +9536,17 @@ plugin-image-zoom@flexanalytics/plugin-image-zoom:
   languageName: node
   linkType: hard
 
-"rehype-katex@npm:4":
-  version: 4.0.0
-  resolution: "rehype-katex@npm:4.0.0"
+"rehype-katex@npm:5":
+  version: 5.0.0
+  resolution: "rehype-katex@npm:5.0.0"
   dependencies:
     "@types/katex": ^0.11.0
     hast-util-to-text: ^2.0.0
-    katex: ^0.12.0
+    katex: ^0.13.0
     rehype-parse: ^7.0.0
     unified: ^9.0.0
     unist-util-visit: ^2.0.0
-  checksum: 974670a12f327b2fab447e16b9db5c2bdcf2d632a40d2123380696eb976fdeb73165376fe79dfd667667969930071275d567c0abc2802570d3bba1023578ad35
+  checksum: b20e24c5326a718581619761057a30d03615519eccd0693ada2c7c710064dceaf08f038ae3a1131550f1f7c47ca54a254ba8e45547da384867e956ceca73f6bf
   languageName: node
   linkType: hard
 

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -2011,7 +2011,7 @@ __metadata:
 
 "@iota-community/iota-wiki-cli@iota-community/iota-wiki-cli#v2":
   version: 1.7.0
-  resolution: "@iota-community/iota-wiki-cli@https://github.com/iota-community/iota-wiki-cli.git#commit=ee983421e6029e4802c69c9adf812c8ab80b0c42"
+  resolution: "@iota-community/iota-wiki-cli@https://github.com/iota-community/iota-wiki-cli.git#commit=62b709be5cec92768985521aaa58bf3d09a5f3b9"
   dependencies:
     "@babel/generator": ^7.17.9
     "@babel/parser": ^7.17.9
@@ -2037,7 +2037,7 @@ __metadata:
     react-dom: ^17.0.2
   bin:
     iota-wiki: dist/index.js
-  checksum: 2c87920005f6cb4985398cd10b1c1f6e7eeb431b00855d785e71f7dd51524a367675060a1416af5d405d93412b251e73c2ca5f6a8fa82e32c9a4bddbef4eaeb5
+  checksum: c8ff6808523df0196c25cb0b54d9c571ab17dbea25ea732b0f7e70cd0105b0759d6adccbdcfc22adc161c087812b1323f6d82a7537c06b92014477bf21afc846
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently, the math equations are not shown correctly in the Wiki. This will update the configuration and packages according to [Docusaurus](https://docusaurus.io/docs/markdown-features/math-equations#configuration) to solve this issue.